### PR TITLE
Prefer /boot/coreos over /boot/flatcar

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -86,12 +86,12 @@ if grep -q cros_legacy /proc/cmdline; then
 elif [[ -z "${INSTALL_KERNEL}" ]]; then
     # not a legacy system but update_engine didn't handle the kernel.
     # kernel names are in lower case, ${SLOT,,} converts the slot name
-    if [ -e "${ESP_MNT}/flatcar" ]; then
-        cp -v "${INSTALL_MNT}/boot/vmlinuz" \
-           "${ESP_MNT}/flatcar/vmlinuz-${SLOT,,}"
-    else
+    if [ -e "${ESP_MNT}/coreos" ]; then
         cp -v "${INSTALL_MNT}/boot/vmlinuz" \
            "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"
+    else
+        cp -v "${INSTALL_MNT}/boot/vmlinuz" \
+           "${ESP_MNT}/flatcar/vmlinuz-${SLOT,,}"
     fi
 fi
 

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -131,23 +131,23 @@ bool OmahaResponseHandlerAction::GetKernelPath(const std::string& part_path,
     return true;
   }
 
-  files::FilePath flatcar_dir = files::FilePath("/boot/flatcar");
+  files::FilePath coreos_dir = files::FilePath("/boot/coreos");
 
   // If the target fs is 3, the kernel name is vmlinuz-a.
   // If the target fs is 4, the kernel name is vmlinuz-b.
   char last_char = part_path[part_path.size() - 1];
   if (last_char == '3') {
-    if (files::PathExists(flatcar_dir))
-      *kernel_path = "/boot/flatcar/vmlinuz-a";
-    else
+    if (files::PathExists(coreos_dir))
       *kernel_path = "/boot/coreos/vmlinuz-a";
+    else
+      *kernel_path = "/boot/flatcar/vmlinuz-a";
     return true;
   }
   if (last_char == '4') {
-    if (files::PathExists(flatcar_dir))
-      *kernel_path = "/boot/flatcar/vmlinuz-b";
-    else
+    if (files::PathExists(coreos_dir))
       *kernel_path = "/boot/coreos/vmlinuz-b";
+    else
+      *kernel_path = "/boot/flatcar/vmlinuz-b";
     return true;
   }
   return false;


### PR DESCRIPTION
For systems that updated from CoreOS CL the
correct path is /boot/coreos/vmlinux-* because
that is what GRUB uses.
Prefer /boot/coreos even if /boot/flatcar exists
to prevent the system from having the boot process
broken.

Note: Create a PR for coreos-overlay after merging (and also pick that for Alpha and Edge when merged).