### PR TITLE
Concatenate URL paths with a slash if missing

### DIFF
--- a/src/update_engine/omaha_request_action.cc
+++ b/src/update_engine/omaha_request_action.cc
@@ -498,6 +498,10 @@ bool OmahaRequestAction::ParsePackage(xmlDoc* doc,
   // propagate the urlBase vs packageName distinctions beyond this point.
   // From now on, we only need to use payload_urls.
   for (size_t i = 0; i < output_object->payload_urls.size(); i++) {
+    // The strings should not be empty but better check that instead of crashing for back() on an empty string
+    if (output_object->payload_urls[i].length() > 0 && output_object->payload_urls[i].back() != '/') {
+      output_object->payload_urls[i] += "/";
+    }
     output_object->payload_urls[i] += package_name;
     LOG(INFO) << "Url" << i << ": " << output_object->payload_urls[i];
   }

--- a/src/update_engine/omaha_request_action_unittest.cc
+++ b/src/update_engine/omaha_request_action_unittest.cc
@@ -379,6 +379,38 @@ TEST(OmahaRequestActionTest, MissingFieldTest) {
   EXPECT_TRUE(response.deadline.empty());
 }
 
+TEST(OmahaRequestActionTest, ConcatUrlSlashTest) {
+  // same as MissingFieldTest above besides the URL
+  string input_response =
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response protocol=\"3.0\">"
+      "<daystart elapsed_seconds=\"100\"/>"
+      "<app appid=\"xyz\" status=\"ok\">"
+      "<updatecheck status=\"ok\">"
+      "<urls><url codebase=\"http://concat/url/slash/test\"/></urls>"
+      "<manifest version=\"1.0.0.0\">"
+      "<packages><package hash=\"not-used\" name=\"f\" "
+      "size=\"587\"/></packages>"
+      "<actions><action event=\"postinstall\" "
+      "Prompt=\"false\" "
+      "IsDelta=\"true\" "
+      "IsDeltaPayload=\"false\" "
+      "sha256=\"lkq34j5345\" "
+      "needsadmin=\"true\" "
+      "/></actions></manifest></updatecheck></app></response>";
+  LOG(INFO) << "Input Response = " << input_response;
+
+  OmahaResponse response;
+  ASSERT_TRUE(TestUpdateCheck(NULL,  // prefs
+                              kDefaultTestParams,
+                              input_response,
+                              -1,
+                              false,  // ping_only
+                              kActionCodeSuccess,
+                              &response,
+                              NULL));
+  EXPECT_EQ("http://concat/url/slash/test/f", response.payload_urls[0]);
+}
+
 namespace {
 class TerminateEarlyTestProcessorDelegate : public ActionProcessorDelegate {
  public:


### PR DESCRIPTION
As detected in
https://github.com/kinvolk/nebraska/pull/152
the URL construction fails if the base URL does
not end with a slash.
Add a slash if it is missing when concatenating
the URL paths.

Fixes https://github.com/flatcar-linux/update_engine/issues/3