### PR TITLE
Prefer /boot/coreos only if /boot/coreos/vmlinux-* exists

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -86,7 +86,7 @@ if grep -q cros_legacy /proc/cmdline; then
 elif [[ -z "${INSTALL_KERNEL}" ]]; then
     # not a legacy system but update_engine didn't handle the kernel.
     # kernel names are in lower case, ${SLOT,,} converts the slot name
-    if [ -e "${ESP_MNT}/coreos" ]; then
+    if [ -e "${ESP_MNT}/coreos/vmlinuz-a" ] || [ -e "${ESP_MNT}/coreos/vmlinuz-b" ]; then
         cp -v "${INSTALL_MNT}/boot/vmlinuz" \
            "${ESP_MNT}/coreos/vmlinuz-${SLOT,,}"
     else

--- a/src/update_engine/omaha_response_handler_action.cc
+++ b/src/update_engine/omaha_response_handler_action.cc
@@ -131,20 +131,21 @@ bool OmahaResponseHandlerAction::GetKernelPath(const std::string& part_path,
     return true;
   }
 
-  files::FilePath coreos_dir = files::FilePath("/boot/coreos");
+  files::FilePath coreos_kernel_a = files::FilePath("/boot/coreos/vmlinuz-a");
+  files::FilePath coreos_kernel_b = files::FilePath("/boot/coreos/vmlinuz-b");
 
   // If the target fs is 3, the kernel name is vmlinuz-a.
   // If the target fs is 4, the kernel name is vmlinuz-b.
   char last_char = part_path[part_path.size() - 1];
   if (last_char == '3') {
-    if (files::PathExists(coreos_dir))
+    if (files::PathExists(coreos_kernel_a) || files::PathExists(coreos_kernel_b))
       *kernel_path = "/boot/coreos/vmlinuz-a";
     else
       *kernel_path = "/boot/flatcar/vmlinuz-a";
     return true;
   }
   if (last_char == '4') {
-    if (files::PathExists(coreos_dir))
+    if (files::PathExists(coreos_kernel_a) || files::PathExists(coreos_kernel_b))
       *kernel_path = "/boot/coreos/vmlinuz-b";
     else
       *kernel_path = "/boot/flatcar/vmlinuz-b";


### PR DESCRIPTION
In case a user or old software created the first_boot flag file under
/boot/coreos instead of /boot/flatcar, the update breaks because /boot/coreos
exists and is prefered ofer /boot/flatcar when the kernel is written.
Make updating more robust by checking if the kernel binaries exist which as least
allows the user to create /boot/coreos/first_boot without breaking the system.

# How to use

See https://github.com/flatcar-linux/scripts/pull/68

# Testing done

Download the qemu image for arm64 from the linked PR above (because the amd64 did reuse the binary package):
```
$ wget https://storage.googleapis.com/flatcar-jenkins/developer/boards/arm64-usr/2345.3.1+dev-flatcar-master-449/flatcar_production_qemu_uefi_image.img.bz2
$ lbunzip2 flatcar_production_qemu_uefi_image.img.bz2
$ wget https://storage.googleapis.com/flatcar-jenkins/developer/boards/arm64-usr/2345.3.1+dev-flatcar-master-449/flatcar_production_qemu_uefi_efi_code.fd
$ wget https://storage.googleapis.com/flatcar-jenkins/developer/boards/arm64-usr/2345.3.1+dev-flatcar-master-449/flatcar_production_qemu_uefi_efi_vars.fd
$ wget https://storage.googleapis.com/flatcar-jenkins/developer/boards/arm64-usr/2345.3.1+dev-flatcar-master-449/flatcar_production_qemu_uefi.sh
$ chmod +x flatcar_production_qemu_uefi.sh
```

1. Boot up the VM and enter via SSH
2. `sudo sh -c 'echo GROUP=alpha > /etc/flatcar/update.conf'`
3. `mkdir /boot/coreos; touch /boot/coreos/first_boot`
4. `cp /usr/share/flatcar/release /tmp; sudo mount --bind /tmp/release /usr/share/flatcar/release`
5. set `FLATCAR_RELEASE_VERSION=0.0.0` in `/usr/share/flatcar/release`
6. `sudo systemctl restart update-engine`
7. `update_engine_client -update`
8. `ls /boot/coreos` should not have a kernel
