### PR TITLE
Report rollbacks as Omaha error codes

### DIFF
--- a/src/update_engine/action_processor.h
+++ b/src/update_engine/action_processor.h
@@ -67,6 +67,7 @@ enum ActionExitCode {
   kActionCodePostinstallPowerwashError = 41,
   kActionCodeNewPCRPolicyVerificationError = 42,
   kActionCodeNewPCRPolicyHTTPError = 43,
+  kActionCodeRollbackError = 44,
 
   // DownloadIncomplete isn't an error to report, it is analogous to EAGAIN
   // and for internal use to indicate that the processing must pause until

--- a/src/update_engine/payload_state.cc
+++ b/src/update_engine/payload_state.cc
@@ -174,6 +174,7 @@ void PayloadState::UpdateFailed(ActionExitCode error) {
     case kActionCodePostinstallPowerwashError:
     case kActionCodeNewPCRPolicyVerificationError:
     case kActionCodeNewPCRPolicyHTTPError:
+    case kActionCodeRollbackError:
       LOG(INFO) << "Not incrementing URL index or failure count for this error";
       break;
 

--- a/src/update_engine/utils.cc
+++ b/src/update_engine/utils.cc
@@ -690,6 +690,8 @@ string CodeToString(ActionExitCode code) {
       return "kActionCodeNewPCRPolicyVerificationError";
     case kActionCodeNewPCRPolicyHTTPError:
       return "kActionCodeNewPCRPolicyHTTPError";
+    case kActionCodeRollbackError:
+      return "kActionCodeRollbackError";
     case kActionCodeDownloadIncomplete:
       return "kActionCodeDownloadIncomplete";
     case kActionCodeOmahaRequestHTTPResponseBase:


### PR DESCRIPTION
When the system failed to boot into an update, a rollback to the
previous partition took place. However, an update success was reported
via Omaha.
Add a new error code that is reported for rollbacks. The detection is
done by comparing the currently running version number with the
previous version number that is already stored for reportting also
serves as a way to detect if a reboot is needed.

# How to use

Build an image with this patch. Then run the following after booting it as VM:
```
sudo -s
echo "GROUP=stable" > /etc/flatcar/update.conf
# optional: use your own Nebraska instance:
# echo "SERVER=http://192.168.1.5:8000/v1/update" >> /etc/flatcar/update.conf
curl -L -o /tmp/key https://raw.githubusercontent.com/flatcar-linux/coreos-overlay/flatcar-master/coreos-base/coreos-au-key/files/official-v2.pub.pem
sudo mount --bind /tmp/key /usr/share/update_engine/update-payload-key.pub.pem
cp /usr/share/flatcar/release /tmp/release
sed -i "/FLATCAR_RELEASE_VERSION=.*/d" /tmp/release
echo FLATCAR_RELEASE_VERSION=0.0.1 >> /tmp/release
mount --bind /tmp/release /usr/share/flatcar/release
systemctl restart update-engine
```
Now force an update:
```
update_engine_client -update
```
When done, run `poweroff` and start the VM, but be quick to select the A partition in GRUB and not the default.
Now the rollback should be detected and reported instead of an update success (wait 45 seconds).
Review the output of `journalctl --all -u update-engine -e`.

# Testing done

The above and some variations like restarting the service during an update download or after the update is prepared to make sure that no false alarm is triggered.