### PR TITLE
Support HTTP Auth credentials for downloads

### DIFF
--- a/src/update_engine/libcurl_http_fetcher.cc
+++ b/src/update_engine/libcurl_http_fetcher.cc
@@ -150,6 +150,9 @@ void LibcurlHttpFetcher::ResumeTransfer(const std::string& url) {
 // Lock down only the protocol in case of HTTP.
 void LibcurlHttpFetcher::SetCurlOptionsForHttp() {
   LOG(INFO) << "Setting up curl options for HTTP";
+  if (!auth_user_.empty()) {
+    LOG(INFO) << "(This is not HTTPS, ignoring HTTP Auth credentials)";
+  }
   CHECK_EQ(curl_easy_setopt(curl_handle_, CURLOPT_PROTOCOLS, CURLPROTO_HTTP),
            CURLE_OK);
   CHECK_EQ(curl_easy_setopt(curl_handle_, CURLOPT_REDIR_PROTOCOLS,
@@ -183,6 +186,11 @@ void LibcurlHttpFetcher::SetCurlOptionsForHttps() {
     CHECK_EQ(curl_easy_setopt(curl_handle_, CURLOPT_SSL_CTX_FUNCTION,
                               CertificateChecker::ProcessSSLContext),
              CURLE_OK);
+  }
+  if (!auth_user_.empty()) {
+    curl_easy_setopt(curl_handle_, CURLOPT_USERNAME, auth_user_.c_str());
+    curl_easy_setopt(curl_handle_, CURLOPT_PASSWORD, auth_password_.c_str());
+    curl_easy_setopt(curl_handle_, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
   }
 }
 

--- a/src/update_engine/libcurl_http_fetcher.h
+++ b/src/update_engine/libcurl_http_fetcher.h
@@ -101,6 +101,13 @@ class LibcurlHttpFetcher : public HttpFetcher {
     check_certificate_ = check_certificate;
   }
 
+  // Sets HTTP Auth user and password for HTTPS connections.
+  // Copies the given credentials.
+  void set_auth_credentials(const char* auth_user, const char* auth_password) {
+    auth_user_ = auth_user;
+    auth_password_ = auth_password;
+  }
+
   virtual size_t GetBytesDownloaded() {
     return static_cast<size_t>(bytes_downloaded_);
   }
@@ -259,6 +266,10 @@ class LibcurlHttpFetcher : public HttpFetcher {
   // connection's certificate. If no certificate check needs to be performed,
   // this should be kNone.
   CertificateChecker::ServerToCheck check_certificate_;
+
+  // If auth_user_ is set cURL HTTP Auth is set up for HTTPS connections.
+  std::string auth_user_;
+  std::string auth_password_;
 
   DISALLOW_COPY_AND_ASSIGN(LibcurlHttpFetcher);
 };

--- a/src/update_engine/omaha_request_params.cc
+++ b/src/update_engine/omaha_request_params.cc
@@ -53,6 +53,8 @@ bool OmahaRequestParams::Init(bool interactive) {
   machineid_ = utils::GetMachineId();
   update_url_ = GetConfValue("SERVER", kProductionOmahaUrl);
   pcr_policy_url_ = GetConfValue("PCR_POLICY_SERVER", "");
+  download_user_ = GetConfValue("DOWNLOAD_USER", "");
+  download_password_ = GetConfValue("DOWNLOAD_PASSWORD", "");
   interactive_ = interactive;
 
   app_channel_ = GetConfValue("GROUP", kDefaultChannel);

--- a/src/update_engine/omaha_request_params.h
+++ b/src/update_engine/omaha_request_params.h
@@ -101,6 +101,9 @@ class OmahaRequestParams {
   inline void set_pcr_policy_url(const std::string& url) { pcr_policy_url_ = url; }
   inline std::string pcr_policy_url() const { return pcr_policy_url_; }
 
+  inline const char* download_user() const { return download_user_.c_str(); }
+  inline const char* download_password() const { return download_password_.c_str(); }
+
   // Suggested defaults
   static const char* const kAppId;
   static const char* const kOsPlatform;
@@ -160,6 +163,10 @@ class OmahaRequestParams {
 
   // The URL to send PCR policy data to.
   std::string pcr_policy_url_;
+
+  // HTTP Auth credentials for downloading the update payload.
+  std::string download_user_;
+  std::string download_password_;
 
   // When reading files, prepend root_ to the paths. Useful for testing.
   std::string root_;

--- a/src/update_engine/update_attempter.cc
+++ b/src/update_engine/update_attempter.cc
@@ -193,6 +193,9 @@ void UpdateAttempter::BuildUpdateActions(bool interactive) {
                              false));
   LibcurlHttpFetcher* download_fetcher = new LibcurlHttpFetcher();
   download_fetcher->set_check_certificate(CertificateChecker::kDownload);
+  download_fetcher->set_auth_credentials(
+      omaha_request_params_->download_user(),
+      omaha_request_params_->download_password());
   shared_ptr<DownloadAction> download_action(
       new DownloadAction(prefs_,
                          new MultiRangeHttpFetcher(


### PR DESCRIPTION
This add user and password variables to the update config file to set
up HTTP Auth credentials for downloading the update payload.

# How to use/testing done

Run a local Nebraska and edit the package of the stable channel to have the base URL https://postman-echo.com/ and the file name `basic-auth`.

Set the version of your image built with this PR after booting in QEMU:
```
cp /usr/share/coreos/release /tmp
sudo mount --bind /tmp/release /usr/share/coreos/release
sudo vi /tmp/release # overwrite version to be 1.1.1
```

Configure update-engine in /etc/flatcar/update.conf and restart the service:
```
SERVER=http://YOURNEBRASKA:PORT/v1/update
GROUP=stable
DOWNLOAD_USER=postman
DOWNLOAD_PASSWORD=password
```

Force an update with `update_engine_client -update` and observe the logs with `journalctl -u update-engine -e` to have either 401 or 200 responses depending on whether the user and password is given or not (restart update-engine after changing the config file).