### PR TITLE
update_engine: remove undefined reference

### DIFF
--- a/src/update_engine/libcurl_http_fetcher.cc
+++ b/src/update_engine/libcurl_http_fetcher.cc
@@ -14,7 +14,6 @@
 #include "update_engine/dbus_interface.h"
 #include "update_engine/utils.h"
 
-using google::protobuf::NewCallback;
 using std::max;
 using std::make_pair;
 using std::string;


### PR DESCRIPTION
This protobuf definition being used is no longer is provided with
libprotobuf-dev 3.12.4-1

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>
