### PR TITLE
flatcar-postinst: create reboot-required flag file for kured

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -446,3 +446,6 @@ call_cgpt show "${INSTALL_DEV}"
 
 cat "${INSTALL_MNT}/share/flatcar/release"
 echo "Setup ${INSTALL_LABEL} (${INSTALL_DEV}) for next boot."
+
+# Create the Ubuntu-compatible /run/reboot-required flag file for kured
+touch /run/reboot-required


### PR DESCRIPTION
While locksmithd and FLUO interact with update-engine through DBus,
kured looks for Ubuntu's /run/reboot-required flag file.
Support kured by creating the flag file in the update post-install
action.


## How to use

Apply an update with `flatcar-update` and see that kured will reboot the machine.

## Testing done

Booted the built image and updated to it:
```
sudo systemctl mask --now locksmithd
wget https://bucket.release.flatcar-linux.net/flatcar-jenkins/developer/developer/boards/amd64-usr/2021.12.06+dev-flatcar-master-4330/flatcar_test_update.gz
sudo flatcar-update -V 1.2.3 -P flatcar_test_update.gz -D
ls /var/run/reboot-required # check that the flag file got created
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ will do in coreos-overlay