### PR TITLE
flatcar-postinst: fix template error command not found

### DIFF
--- a/flatcar-postinst
+++ b/flatcar-postinst
@@ -339,7 +339,7 @@ if [[ "${BUILD_ID}" != "dev-"* ]]; then
 # Automatically added during update from ${VERSION_ID} to ${NEXT_VERSION_ID}
 # Flatcar has migrated to cgroup v2. Your node has been kept on cgroup v1.
 # Migrate at your own convenience by changing the value to '=1', or remove this
-# line if you don't need to switch back ('systemd.legacy_systemd_cgroup_controller' only has effect for `=0`).
+# line if you don't need to switch back ('systemd.legacy_systemd_cgroup_controller' only has effect for '=0').
 # For more details visit:
 # https://kinvolk.io/docs/flatcar-container-linux/latest/container-runtimes/switching-to-unified-cgroups
 set linux_append="\$linux_append systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller"


### PR DESCRIPTION
The heredoc treated `=0` like $(=0), replacing this part of the
template with an empty string and logging "=0: commad not found".
Replace backticks by simple quotes which are not treated specially in
the template.

## How to use

Update commit ID in overlay and backport to stable

## Testing done

Manual execution of the cat command.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ TODO in coreos-overlay